### PR TITLE
Fix opcache on PHP > 7.0

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -739,8 +739,10 @@ class WP_Object_Cache
         touch( $file_path, $this->start_time - 10 );
         $return = rename( $tmp, $file_path );
 
-	    @opcache_invalidate( $file_path, true );
-	    @opcache_compile_file( $file_path );
+        if ( $this->enabled ) {
+	        @opcache_invalidate( $file_path, true );
+	        @opcache_compile_file( $file_path );
+        }
 
 	    return $return;
     }

--- a/tests/tests/add.php
+++ b/tests/tests/add.php
@@ -81,7 +81,7 @@ class OpcacheUnitTestsAdd extends OpcacheUnitTests
         $this->assertFalse($this->object_cache->add($key, $value));
 
         // Verify that the value does not exist in cache
-        $this->assertNull($this->object_cache->get($key));
+        $this->assertFalse($this->object_cache->get($key));
     }
 
     /**
@@ -99,7 +99,7 @@ class OpcacheUnitTestsAdd extends OpcacheUnitTests
         $this->assertFalse($this->object_cache->add($key, $value));
 
         // Verify that the value does not exist in cache
-        $this->assertNull($this->object_cache->get($key));
+        $this->assertFalse($this->object_cache->get($key));
 
         $key = microtime();
         $value = 'carruth';

--- a/tests/tests/delete.php
+++ b/tests/tests/delete.php
@@ -19,7 +19,7 @@ class OpcacheUnitTestsDelete extends OpcacheUnitTests
         $this->assertTrue($this->object_cache->delete($key));
 
         // Verify that key is not gettable after delete
-        $this->assertNull($this->object_cache->get($key));
+        $this->assertFalse($this->object_cache->get($key));
 
         // Verify that I can add a new value with this key
         $this->assertTrue($this->object_cache->add($key, $value2));
@@ -47,7 +47,7 @@ class OpcacheUnitTestsDelete extends OpcacheUnitTests
         $this->assertTrue($this->object_cache->delete($key, $group));
 
         // Verify that key is not gettable after delete
-        $this->assertNull($this->object_cache->get($key, $group));
+        $this->assertFalse($this->object_cache->get($key, $group));
 
         // Verify that I can add a new value with this key
         $this->assertTrue($this->object_cache->add($key, $value2, $group));

--- a/tests/tests/get.php
+++ b/tests/tests/get.php
@@ -74,9 +74,9 @@ class OpcacheUnitTestsGet extends OpcacheUnitTests
         $this->assertTrue($this->object_cache->delete($key, $group));
 
         // Verify that false is returned
-        $this->assertNull($this->object_cache->get($key, $group, false, $found));
+        $this->assertFalse($this->object_cache->get($key, $group, false, $found));
 
-        // Verify that found variable is set to true because the item was found
-        $this->assertTrue($found);
+        // Verify that found variable is set to false because the item was deleted and not found
+        $this->assertFalse($found);
     }
 }

--- a/tests/tests/other.php
+++ b/tests/tests/other.php
@@ -22,7 +22,7 @@ class OpcacheUnitTestsAll extends OpcacheUnitTests
         $this->assertTrue($this->object_cache->flush());
 
         // Make sure value is no longer available
-        $this->assertNull($this->object_cache->get($key));
+        $this->assertFalse($this->object_cache->get($key));
     }
 
     public function test_switch_to_blog()

--- a/tests/tests/replace.php
+++ b/tests/tests/replace.php
@@ -26,7 +26,7 @@ class OpcacheUnitTestsReplace extends OpcacheUnitTests
 
         $this->assertFalse($this->object_cache->replace($key, $value));
 
-        $this->assertNull($this->object_cache->get($key));
+        $this->assertFalse($this->object_cache->get($key));
     }
 
     public function test_replace_with_expiration_of_30_days()


### PR DESCRIPTION
Success is better detected by include's return value. Returning exiration
and value as array instead of assigning to vars is more reliable.
Borrows many ideas from The Synfony PhpFileCache
https://github.com/symfony/cache/blob/master/Traits/PhpFilesTrait.php
Should work in any version of php which supports opcache

fixes #3  and like all the issues.