### PR TITLE
Fixed file not found errors.

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -583,7 +583,10 @@ class WP_Object_Cache
             }
         }
 
-        $result = @include $this->filePath($key, $group);
+	$result = false;
+        if (file_exists($file_path = $this->filePath($key, $group))) {
+                $result = include $file_path;
+        }
         if (false === $result) {
             // file did not exist.
             $success = false;


### PR DESCRIPTION
Problem
- Analyzing the site performance with Query Monitor, a lot of PHP errors are appearing in the error log, because the object cache tries to read files that do not exist.

Proposed solution
1. Test whether the file exists before including it. Avoid error suppression.

Notes
- It can be argued that the `file_exists()` involves additional I/O because of an extra file stat. But PHP's error handling also does not come for free.